### PR TITLE
feat: add throttled version of draw

### DIFF
--- a/xichecklist.lua
+++ b/xichecklist.lua
@@ -527,7 +527,8 @@ function update_maintab()
 end
 
 windower.register_event('incoming chunk', function(id, data, modified, injected, blocked)
-	
+	if injected then return end
+
 	if id == 0x01B then
 		local parseddata = packets.parse('incoming', data)
 		if (parseddata['Mastery Rank'] > playertracker['mastery_rank']) then
@@ -661,11 +662,23 @@ windower.register_event('incoming chunk', function(id, data, modified, injected,
 		-- claer npc menu
 		menus_util.reset_current_menu()
 	end
-	
-	update_maintab()
-	--xichecklist_updatetabs()
-	if trackermenusettings.visibility then draw() end
+
+	throttled_update()
 end)
+
+THROTTLED = false
+function throttled_update()
+	if THROTTLED then return end
+	THROTTLED = true
+	coroutine.sleep(0.1)
+	-- Drop errors on the ground so we're never locked in THROTTLED = true
+	pcall(function ()
+		update_maintab()
+		--xichecklist_updatetabs()
+		if trackermenusettings.visibility then draw() end
+	end)
+	THROTTLED = false
+end
 
 windower.register_event('outgoing chunk', function(id, data, modified, injected, blocked)
 	


### PR DESCRIPTION
This PR does two things:
1. It rejects injected incoming packets, because they don't necessarily have true information 
2. It introduces a throttled update function that only calls the expensive functions once every 0.1 seconds

Why 0.1 seconds? Well, the incoming chunk event is called once per incoming chunk and there are many incoming chunks in an incoming UDP packet, so in practice it's getting called 1~50 times per incoming UDP packet arrival, all between the same two frames. Getting called once in your mog house when you're not getting many chunks may be fine, but out in the mean streets of Adoulin when you're getting slammed, it causes stuttering. Throwing a 0.1 second delay on there both makes sure it's being processed at a different time than the incoming packet (already a heavy frame) and functionally combines all the updates. You get packets about once every 0.25 seconds with packetflow or 0.4 seconds without, so you're still getting one update per UDP packet.